### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "lint:js": "./node_modules/.bin/eslint \"src/**/*.js\"",
     "lint:styles": "stylelint \"src/**/*.scss\"",
     "lint": "npm run lint:html && npm run lint:styles && npm run lint:js",
-    "fix": "./node_modules/.bin/eslint --fix \"src/**/*.js\" && stylelint --fix \"src/**/*.scss\"",
+    "fix:js": "./node_modules/.bin/eslint --fix \"src/**/*.js\"",
+    "fix:css": "stylelint --fix \"src/**/*.scss\"",
+    "fix": "npm run fix:css && npm run fix:js",
     "build": "cross-env NODE_ENV=production webpack --config ./config/webpack.config.js",
     "deploy": "npm run build && gh-pages -d dist"
   },


### PR DESCRIPTION
Allow CSS and JS fixes to be run separately.

To use this, delete `package-lock.json` and rerun `npm install`. You'll have the following new commands:

- `npm run fix`
- `npm run fix:css` - Fixes just your CSS
- `npm run fix:js` - Fixes just your JS

There are some errors it won't be able to fix automatically. If you have any of those errors, it is up to you and your team to solve them :) 